### PR TITLE
Parse trgt entries - FORMAT.MC in practice - also if VCF not split

### DIFF
--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -7,7 +7,7 @@ from pprint import pprint as pp
 from codecs import (open, getreader)
 
 from stranger.resources import repeats_json_path
-from stranger.utils import (parse_repeat_file, get_repeat_info, get_format_dict, get_info_dict, get_variant_line)
+from stranger.utils import (get_format_dicts, get_info_dict, get_repeat_info, get_variant_line, parse_repeat_file)
 from stranger.vcf_utils import print_headers
 from stranger.constants import ANNOTATE_REPEAT_KEYS
 from stranger.__version__ import __version__
@@ -149,8 +149,6 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
 
 
         if repeat_data:
-            if needs_split(repeat_data):
-
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
             variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper'])

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -147,7 +147,6 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
 
         repeat_data = get_repeat_info(variant_info, repeat_information)
 
-
         if repeat_data:
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -7,7 +7,7 @@ from pprint import pprint as pp
 from codecs import (open, getreader)
 
 from stranger.resources import repeats_json_path
-from stranger.utils import (parse_repeat_file, get_repeat_info, get_info_dict, get_variant_line)
+from stranger.utils import (parse_repeat_file, get_repeat_info, get_format_dict, get_info_dict, get_variant_line)
 from stranger.vcf_utils import print_headers
 from stranger.constants import ANNOTATE_REPEAT_KEYS
 from stranger.__version__ import __version__
@@ -30,12 +30,13 @@ def print_version(ctx, param, value):
     show_default=True,
 )
 @click.option('-i','--family_id', default='1')
+@click.option('-t','--trgt', is_flag=True, help='File was produced with TRGT')
 @click.option('--version', is_flag=True, callback=print_version,
               expose_value=False, is_eager=True)
 @click.option('--loglevel', default='INFO', type=click.Choice(LOG_LEVELS),
               help="Set the level of log output.", show_default=True)
 @click.pass_context
-def cli(context, vcf, family_id, repeats_file, loglevel):
+def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
     """Annotate str variants with str status"""
     coloredlogs.install(level=loglevel)
     LOG.info("Running stranger version %s", __version__)
@@ -53,7 +54,7 @@ def cli(context, vcf, family_id, repeats_file, loglevel):
         LOG.warning("Could not find any repeat info")
         context.abort()
 
-    header_definitions = [
+    header_info_definitions = [
         {
             'id': 'STR_STATUS', 'num': 'A', 'type': 'String',
             'desc': 'Repeat expansion status. Alternatives in [normal, pre_mutation, full_mutation]'
@@ -109,11 +110,10 @@ def cli(context, vcf, family_id, repeats_file, loglevel):
     ]
 
     stranger_headers = []
-    for hdef in header_definitions:
+    for hdef in header_info_definitions:
         header = '##INFO=<ID={0},Number={1},Type={2},Description="{3}">'.format(
             hdef.get('id'), hdef.get('num'), hdef.get('type'), hdef.get('desc'))
         stranger_headers.append(header)
-
 
     if vcf.endswith('.gz'):
         LOG.info("Vcf is zipped")
@@ -121,7 +121,6 @@ def cli(context, vcf, family_id, repeats_file, loglevel):
     else:
         vcf_handle = open(vcf, mode='r', encoding='utf-8', errors='replace')
 
-    LOG.info("Parsing variants from %s", vcf)
     for line in vcf_handle:
         line = line.rstrip()
         if line.startswith('#'):
@@ -138,8 +137,20 @@ def cli(context, vcf, family_id, repeats_file, loglevel):
         variant_info = dict(zip(header_info, line.split('\t')))
         variant_info['alts'] = variant_info['ALT'].split(',')
         variant_info['info_dict'] = get_info_dict(variant_info['INFO'])
+
+        if trgt:
+            for index, item in enumerate(header_info):
+                if item.startswith('FORMAT'):
+                    individual_index = index + 1
+
+            variant_info['format_dicts'] = get_format_dicts(variant_info['FORMAT'], [variant_info[individual] for individual in header_info[individual_index:]])
+
         repeat_data = get_repeat_info(variant_info, repeat_information)
+
+
         if repeat_data:
+            if needs_split(repeat_data):
+
             variant_info['info_dict']['STR_STATUS'] = repeat_data['repeat_strings']
             variant_info['info_dict']['STR_NORMAL_MAX'] = str(repeat_data['lower'])
             variant_info['info_dict']['STR_PATHOLOGIC_MIN'] = str(repeat_data['upper'])
@@ -148,4 +159,6 @@ def cli(context, vcf, family_id, repeats_file, loglevel):
                 if repeat_data.get(annotate_repeat_key):
                     variant_info['info_dict'][annotate_repeat_key] = str(repeat_data[annotate_repeat_key])
 
+
         click.echo(get_variant_line(variant_info, header_info))
+

--- a/stranger/constants.py
+++ b/stranger/constants.py
@@ -15,3 +15,14 @@ ANNOTATE_REPEAT_KEYS = [
     'SweGenStd',
     'Disease',
 ]
+
+ANNOTATE_REPEAT_KEYS_TRGT = [
+    'HGNCId',
+    'InheritanceMode',
+    'DisplayRU',
+    'SourceDisplay',
+    'Source',
+    'SourceId',
+    'Disease',
+    'Struc'
+]

--- a/stranger/resources/variant_catalog_grch37.json
+++ b/stranger/resources/variant_catalog_grch37.json
@@ -46,6 +46,7 @@
     {
         "VariantType": "Repeat",
         "LocusId": "ARX_EIEE",
+        "TRID": "EIEE1_ARX",
         "HGNCId": 18060,
         "InheritanceMode": "XR",
         "DisplayRU": "GCN",
@@ -150,6 +151,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
+        "PathogenicStruc": [0],
         "ReferenceRegion": "3:63898361-63898391",
         "VariantType": "Repeat",
         "Disease": "SCA7",
@@ -168,6 +170,7 @@
         "SweGenMean": 14.13,
         "SweGenStd": 5.481,
         "LocusStructure": "(CTA)*(CTG)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "13:70713485-70713515",
             "13:70713515-70713560"
@@ -188,6 +191,7 @@
     {
         "VariantType": "RareRepeat",
         "LocusId": "C9ORF72",
+        "TRID": "FTDALS1_C9orf72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
         "DisplayRU": "GGGGCC",
@@ -296,6 +300,7 @@
             "3:128891499-128891539",
             "3:128891539-128891575"
         ],
+        "PathologicStruc": [0],
         "VariantType": [
             "Repeat",
             "Repeat",
@@ -340,6 +345,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK541729",
         "LocusStructure": "(AAAAT)*(GAAAT)*(AAAAT)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "1:57832715-57832725",
             "1:57832725-57832780",
@@ -417,6 +423,7 @@
             "EIF4A3",
             "EIF4A3_CACA20"
         ],
+        "PathologicStruc": [0],
         "PathologicRegion": "17:78120821-78120840",
         "NormalMax": 9,
         "PathologicMin": 10
@@ -620,6 +627,7 @@
         "SweGenMean": 6.099,
         "SweGenStd": 1.807,
         "LocusStructure": "(GGCCTG)*(CGCCTG)*",
+        "PathologicStruc": [0],
         "ReferenceRegion": [
             "20:2633379-2633403",
             "20:2633403-2633421"

--- a/stranger/resources/variant_catalog_grch38.json
+++ b/stranger/resources/variant_catalog_grch38.json
@@ -44,6 +44,7 @@
     {
         "VariantType": "Repeat",
         "LocusId": "ARX_EIEE",
+        "TRID": "EIEE1_ARX",
         "HGNCId": 18060,
         "InheritanceMode": "XR",
         "DisplayRU": "GCN",
@@ -141,6 +142,7 @@
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
         "ReferenceRegion": "3:63912684-63912714",
+        "PathogenicStruc": [0],
         "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
@@ -175,6 +177,7 @@
     },
     {
         "LocusId": "C9ORF72",
+        "TRID": "FTDALS1_C9orf72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
         "DisplayRU": "GGGGCC",
@@ -324,6 +327,7 @@
             "3:129172656-129172696",
             "3:129172696-129172732"
         ],
+        "PathologicStruc": [0],
         "VariantId": [
             "CNBP",
             "CNBP_CAGA",
@@ -364,6 +368,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK541729",
         "LocusStructure": "(AAAAT)*(GAAAT)*(AAAAT)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "1:57367043-57367053",
             "1:57367053-57367108",
@@ -438,6 +443,7 @@
             "EIF4A3",
             "EIF4A3_CACA20"
         ],
+        "PathologicStruc": [0],
         "PathologicRegion": "17:80147022-80147041",
         "NormalMax": 9,
         "PathologicMin": 10
@@ -825,6 +831,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK231880",
         "LocusStructure": "(GGCCTG)*(CGCCTG)*",
+        "PathologicStruc": [0],
         "ReferenceRegion": [
             "20:2652733-2652757",
             "20:2652757-2652775"

--- a/stranger/resources/variant_catalog_hg19.json
+++ b/stranger/resources/variant_catalog_hg19.json
@@ -46,6 +46,7 @@
     {
         "VariantType": "Repeat",
         "LocusId": "ARX_EIEE",
+        "TRID": "EIEE1_ARX",
         "HGNCId": 18060,
         "InheritanceMode": "XR",
         "DisplayRU": "GCN",
@@ -150,6 +151,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
+        "PathogenicStruc": [0],
         "ReferenceRegion": "chr3:63898361-63898391",
         "VariantType": "Repeat",
         "Disease": "SCA7",
@@ -168,6 +170,7 @@
         "SweGenMean": 14.13,
         "SweGenStd": 5.481,
         "LocusStructure": "(CTA)*(CTG)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr13:70713485-70713515",
             "chr13:70713515-70713560"
@@ -188,6 +191,7 @@
     {
         "VariantType": "RareRepeat",
         "LocusId": "C9ORF72",
+        "TRID": "FTDALS1_C9orf72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
         "DisplayRU": "GGGGCC",
@@ -296,6 +300,7 @@
             "chr3:128891499-128891539",
             "chr3:128891539-128891575"
         ],
+        "PathologicStruc": [0],
         "VariantType": [
             "Repeat",
             "Repeat",
@@ -340,6 +345,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK541729",
         "LocusStructure": "(AAAAT)*(GAAAT)*(AAAAT)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr1:57832715-57832725",
             "chr1:57832725-57832780",
@@ -417,6 +423,7 @@
             "EIF4A3",
             "EIF4A3_CACA20"
         ],
+        "PathologicStruc": [0],
         "PathologicRegion": "chr17:78120821-78120840",
         "NormalMax": 9,
         "PathologicMin": 10
@@ -620,6 +627,7 @@
         "SweGenMean": 6.099,
         "SweGenStd": 1.807,
         "LocusStructure": "(GGCCTG)*(CGCCTG)*",
+        "PathologicStruc": [0],
         "ReferenceRegion": [
             "chr20:2633379-2633403",
             "chr20:2633403-2633421"

--- a/stranger/resources/variant_catalog_hg38.json
+++ b/stranger/resources/variant_catalog_hg38.json
@@ -44,6 +44,7 @@
     {
         "VariantType": "Repeat",
         "LocusId": "ARX_EIEE",
+        "TRID": "EIEE1_ARX",
         "HGNCId": 18060,
         "InheritanceMode": "XR",
         "DisplayRU": "GCN",
@@ -141,6 +142,7 @@
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
         "ReferenceRegion": "chr3:63912684-63912714",
+        "PathogenicStruc": [0],
         "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,
@@ -156,6 +158,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CTA)*(CTG)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr13:70139353-70139383",
             "chr13:70139383-70139428"
@@ -175,6 +178,7 @@
     },
     {
         "LocusId": "C9ORF72",
+        "TRID": "FTDALS1_C9orf72",
         "HGNCId": 28337,
         "InheritanceMode": "AD",
         "DisplayRU": "GGGGCC",
@@ -324,6 +328,7 @@
             "chr3:129172656-129172696",
             "chr3:129172696-129172732"
         ],
+        "PathologicStruc": [0],
         "VariantId": [
             "CNBP",
             "CNBP_CAGA",
@@ -364,6 +369,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK541729",
         "LocusStructure": "(AAAAT)*(GAAAT)*(AAAAT)*",
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr1:57367043-57367053",
             "chr1:57367053-57367108",
@@ -438,6 +444,7 @@
             "EIF4A3",
             "EIF4A3_CACA20"
         ],
+        "PathologicStruc": [0],
         "PathologicRegion": "chr17:80147022-80147041",
         "NormalMax": 9,
         "PathologicMin": 10
@@ -825,6 +832,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK231880",
         "LocusStructure": "(GGCCTG)*(CGCCTG)*",
+        "PathologicStruc": [0],
         "ReferenceRegion": [
             "chr20:2652733-2652757",
             "chr20:2652757-2652775"

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -284,17 +284,6 @@ def get_variant_line(variant_info, header_info):
             info_list.append('='.join([annotation, info_dict[annotation]]))
         variant_info['INFO'] = ';'.join(info_list)
 
-    format_dict = variant_info['format_dict']
-    format_list = []
-    for annotation in format_dict:
-        if format_dict[annotation] is None:
-            format_list.append(annotation)
-            continue
-        format_list.append(annotation)
-        variant_info['FORMAT'] = ''
-
-
-
     variant_list = []
     for annotation in header_info:
         variant_list.append(variant_info[annotation])


### PR DESCRIPTION
### This PR adds | fixes:
- start parsing TRGT VCF
- Fix #46
- Fix #51 

Ideally we should also address:
- [x] update repid handling for trid
- [x] default to all motif parts of locus counting towards pathogenicity if no “pathogenic_struc” defined specified in repeat info JSON
- [x] update TRID etc also for hg38 demo reference

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
