### PR TITLE
afterthought: typo pathogenic

### DIFF
--- a/stranger/constants.py
+++ b/stranger/constants.py
@@ -25,4 +25,5 @@ ANNOTATE_REPEAT_KEYS_TRGT = [
     'SourceId',
     'Disease',
     'Struc'
+    'PathologicStruc'
 ]

--- a/stranger/resources/variant_catalog_grch37.json
+++ b/stranger/resources/variant_catalog_grch37.json
@@ -151,7 +151,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
-        "PathogenicStruc": [0],
+        "PathologicStruc": [0],
         "ReferenceRegion": "3:63898361-63898391",
         "VariantType": "Repeat",
         "Disease": "SCA7",

--- a/stranger/resources/variant_catalog_grch38.json
+++ b/stranger/resources/variant_catalog_grch38.json
@@ -142,7 +142,7 @@
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
         "ReferenceRegion": "3:63912684-63912714",
-        "PathogenicStruc": [0],
+        "PathologicStruc": [0],
         "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,

--- a/stranger/resources/variant_catalog_hg19.json
+++ b/stranger/resources/variant_catalog_hg19.json
@@ -151,7 +151,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
-        "PathogenicStruc": [0],
+        "PathologicStruc": [0],
         "ReferenceRegion": "chr3:63898361-63898391",
         "VariantType": "Repeat",
         "Disease": "SCA7",

--- a/stranger/resources/variant_catalog_hg38.json
+++ b/stranger/resources/variant_catalog_hg38.json
@@ -142,7 +142,7 @@
         "SourceId": "NBK535148",
         "LocusStructure": "(CAG)*",
         "ReferenceRegion": "chr3:63912684-63912714",
-        "PathogenicStruc": [0],
+        "PathologicStruc": [0],
         "VariantType": "Repeat",
         "Disease": "SCA7",
         "NormalMax": 19,


### PR DESCRIPTION
### This PR adds | fixes:
- a typo in the references, and an afterthought to pass on that pathologic structure key to output.

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
-

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
