### PR TITLE
Fix #63 - fallback if MC is .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+- Fallback setting allele size to 0 if MC is only set to "." and TRGT annotation requested
+
 ## [0.9.0]
 - Add Docker image
 - Parse TRGT VCFs - in particular, decompose and parse FORMAT.MC

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -258,6 +258,7 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                 # What should we do if MC is . ?
                 if allele == ".":
                     repeat_res.extend([0])
+                    continue
 
                 if len(mcs) > 1:
                     pathologic_mcs = repeat_info[repeat_id].get('pathologic_struc', range(len(mcs)))


### PR DESCRIPTION
## Description

### Fixed

- Fallback setting allele size to 0 if MC is only set to "." and TRGT annotation requested



### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Run stranger on TRGT style VCF with "." for GT.MC


### Expected test outcome

- [x] Check that allele size is now set to 0 after, and crash does not occur.
![Screenshot 2024-07-01 at 11 06 49](https://github.com/Clinical-Genomics/stranger/assets/758570/49444456-b42e-4197-b05e-663566629527)

- [x] Take a screenshot and attach or copy/paste the output.

Before:
❌ ![Screenshot 2024-07-01 at 11 07 00](https://github.com/Clinical-Genomics/stranger/assets/758570/3c8491b0-28f3-4cfb-9c34-90e242410d13)

After:
✅  ![Screenshot 2024-07-01 at 11 06 28](https://github.com/Clinical-Genomics/stranger/assets/758570/a73a187d-61e2-4001-b665-1fbb1056fd1a)

## Review

- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
