### PR TITLE
Fix #73 - out format for multiindividuals decompose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added a test for TRGT MCs set to `.`
 - Added CLI test for TRGT file
 - Fix codecov upload hidden artifact issue
+- Incorrect multisample, multiallele FORMAT output
 
 ## [0.9.1]
 ### Added

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -382,7 +382,7 @@ def update_decomposed_variant_format_fields(variant_info, header_info, individua
     Update variant_info individual FORMAT fields with information found in the now up to date
     format_dicts.
     """
-    
+
     individuals = [individual for individual in header_info[individual_index:]]
 
     for index, format_dict in enumerate(variant_info["format_dicts"]):

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -382,11 +382,11 @@ def update_decomposed_variant_format_fields(variant_info, header_info, individua
     Update variant_info individual FORMAT fields with information found in the now up to date
     format_dicts.
     """
-    out_format = []
-
+    
     individuals = [individual for individual in header_info[individual_index:]]
 
     for index, format_dict in enumerate(variant_info["format_dicts"]):
+        out_format = []
         for field in variant_info["FORMAT"].split(":"):
             out_format.append(format_dict[field])
 


### PR DESCRIPTION
## Description

### Fixed

- Fix #73 - output FORMAT incorrect for multiple individuals after (TRGT) decompose


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
