### PR TITLE
Fix #76 - revert to output unannotated loci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use codecov badge and fix scout link on README page
 - Added a test for TRGT MCs set to `.`
 - Added CLI test for TRGT file
-- Fix codecov upload hidden artifact issue
+- Codecov upload hidden artifact issue
 - Incorrect multisample, multiallele FORMAT output
+- Write unannotated entries (not in definition file) to output (reverted to pre-0.9 behaviour)
 
 ## [0.9.1]
 ### Added

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -211,4 +211,4 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
                             repeat_data[annotate_repeat_key]
                         )
 
-                click.echo(get_variant_line(variant_info, header_info))
+            click.echo(get_variant_line(variant_info, header_info))


### PR DESCRIPTION
## Description

### Fixed

- Fix #76 - revert to allow output of unannotated loci

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
