### PR TITLE
Most severe string for decompose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+### Fixed
+- Set STR_STATUS to most severe consequence for given repeat strings (TRGT decompose)
+
 ## [0.9.4]
 ### Fixed
 - Bug with no ref on multi-allele FORMAT decompose

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -195,7 +195,7 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
             repeat_data = get_repeat_info(variant_info, repeat_information)
 
             if repeat_data:
-                variant_info["info_dict"]["STR_STATUS"] = repeat_data["repeat_strings"]
+                variant_info["info_dict"]["STR_STATUS"] = repeat_data["most_severe_repeat_string"]
                 variant_info["info_dict"]["STR_NORMAL_MAX"] = str(repeat_data["lower"])
                 variant_info["info_dict"]["STR_PATHOLOGIC_MIN"] = str(repeat_data["upper"])
                 variant_info["info_dict"]["RankScore"] = ":".join(

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -195,12 +195,12 @@ def get_repeat_id(variant_info):
     return trid
 
 
-def get_repeat_info(variant_info, repeat_info):
+def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
     """Find the correct mutation level of a str variant
 
     Args:
-        variant_line(str): A vcf variant line
-        repeat_info(dict)
+        variant_info(dict): A variant info dict (from VCF)
+        repeat_info(dict): A repeat info dict (from config catalog)
 
     Returns:
         (dict): With repeat level, lower and upper limits
@@ -217,6 +217,7 @@ def get_repeat_info(variant_info, repeat_info):
     rep_upper = repeat_info[repeat_id].get("pathologic_min", -1)
     rank_score = 0
 
+    repeat_string = ""
     repeat_strings = []
 
     if variant_info.get("format_dicts"):
@@ -229,16 +230,20 @@ def get_repeat_info(variant_info, repeat_info):
             repeat_strings.append("normal")
             if rank_score < RANK_SCORE["normal"]:
                 rank_score = RANK_SCORE["normal"]
+                repeat_string = "normal"
         elif repeat_number < rep_upper:
             repeat_strings.append("pre_mutation")
             if rank_score < RANK_SCORE["pre_mutation"]:
                 rank_score = RANK_SCORE["pre_mutation"]
+                repeat_string = "pre_mutation"
         else:
             repeat_strings.append("full_mutation")
             rank_score = RANK_SCORE["full_mutation"]
+            repeat_string = "full_mutation"
 
     repeat_data = dict(
-        repeat_strings=",".join(repeat_strings),
+        most_severe_repeat_string=repeat_string,
+        repeat_strings=repeat_strings,
         lower=rep_lower,
         upper=rep_upper,
         rank_score=rank_score,
@@ -345,7 +350,7 @@ def get_variant_line(variant_info, header_info):
         header_info(list)
 
     Returns:
-        variant_string(str): VCF formated variant
+        variant_string(str): VCF formatted variant
     """
 
     info_dict = variant_info["info_dict"]


### PR DESCRIPTION
## Description

### Fixed
- Fix #89 

### How to test

- [ ] Do ...

❌  Before:
```
➜  stranger git:(main) ✗ uv run stranger --loglevel DEBUG --trgt multisample.vcf --repeats-file stranger/resources/variant_catalog_grch38.json
...
HG002_Revio_B_haplotagged
chr20	2652734	.	GGCCTGGGCCTGGGCCTGGGCCTGC	AGCCTGGGCCTGGGCCTGG	0	.	TRID=NOP56;END=2652775;MOTIFS=GGCCTG,CGCCTG;STRUC=(GGCCTG)n(CGCCTG)n;STR_STATUS=normal,normal;STR_NORMAL_MAX=14;STR_PATHOLOGIC_MIN=650;RankScore=1:10;HGNCId=15911;InheritanceMode=AD;DisplayRU=GGCCTG;SourceDisplay=GeneReviews Internet 2014-08-07;Source=GeneReviews;SourceId=NBK231880;Disease=SCA36	GT:AL:ALLR:SD:MC:MS:AP:AM	1/.:36:36-36:12:4_2:0(0-24)_1(24-36):0.972222:69	1/.:36:36-36:24:4_2:0(0-24)_1(24-36):0.972222:68
chr20	2652734	.	GGCCTGGGCCTGGGCCTGGGCCTGC	AGCCTGGGCCTGGGCCTGGGCCTGGGCCTGGGCCTGG	0	.	TRID=NOP56;END=2652775;MOTIFS=GGCCTG,CGCCTG;STRUC=(GGCCTG)n(CGCCTG)n;STR_STATUS=normal,normal;STR_NORMAL_MAX=14;STR_PATHOLOGIC_MIN=650;RankScore=1:10;HGNCId=15911;InheritanceMode=AD;DisplayRU=GGCCTG;SourceDisplay=GeneReviews Internet 2014-08-07;Source=GeneReviews;SourceId=NBK231880;Disease=SCA36	GT:AL:ALLR:SD:MC:MS:AP:AM	./1:54:52-54:18:7_2:0(0-42)_1(42-54):0.981481:118	./1:54:52-54:36:7_2:0(0-42)_1(42-54):0.981481:116
```

✅ After:
```
➜  stranger git:(most_severe_string_for_decompose) ✗ uv run stranger --loglevel DEBUG --trgt multisample.vcf --repeats-file stranger/resources/variant_catalog_grch38.json
...
##INFO=<ID=RankScore,Number=1,Type=String,Description="RankScore for variant in this family as family(str):score(int)">
##INFO=<ID=Disease,Number=1,Type=String,Description="Associated disorder">
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	HG002_Revio_A_haplotagged	HG002_Revio_B_haplotagged
chr20	2652734	.	GGCCTGGGCCTGGGCCTGGGCCTGC	AGCCTGGGCCTGGGCCTGG	0	.	TRID=NOP56;END=2652775;MOTIFS=GGCCTG,CGCCTG;STRUC=(GGCCTG)n(CGCCTG)n;STR_STATUS=normal;STR_NORMAL_MAX=14;STR_PATHOLOGIC_MIN=650;RankScore=1:10;HGNCId=15911;InheritanceMode=AD;DisplayRU=GGCCTG;SourceDisplay=GeneReviews Internet 2014-08-07;Source=GeneReviews;SourceId=NBK231880;Disease=SCA36	GT:AL:ALLR:SD:MC:MS:AP:AM	1/.:36:36-36:12:4_2:0(0-24)_1(24-36):0.972222:69	1/.:36:36-36:24:4_2:0(0-24)_1(24-36):0.972222:68
chr20	2652734	.	GGCCTGGGCCTGGGCCTGGGCCTGC	AGCCTGGGCCTGGGCCTGGGCCTGGGCCTGGGCCTGG	0	.	TRID=NOP56;END=2652775;MOTIFS=GGCCTG,CGCCTG;STRUC=(GGCCTG)n(CGCCTG)n;STR_STATUS=normal;STR_NORMAL_MAX=14;STR_PATHOLOGIC_MIN=650;RankScore=1:10;HGNCId=15911;InheritanceMode=AD;DisplayRU=GGCCTG;SourceDisplay=GeneReviews Internet 2014-08-07;Source=GeneReviews;SourceId=NBK231880;Disease=SCA36	GT:AL:ALLR:SD:MC:MS:AP:AM	./1:54:52-54:18:7_2:0(0-42)_1(42-54):0.981481:118	./1:54:52-54:36:7_2:0(0-42)_1(42-54):0.981481:116
```

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
