### PR TITLE
Fix TRGT pathogenic motif count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Fixed
 - Set STR_STATUS to most severe consequence for given repeat strings (TRGT decompose)
+- Fixed TRGT pathogenic motif count reporting sum of both alleles instead of max
 
 ## [0.9.4]
 ### Fixed

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -224,6 +224,8 @@ def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
         repeat_res = get_trgt_repeat_res(variant_info, repeat_info)
     else:
         repeat_res = get_exhu_repeat_res_from_alts(variant_info)
+    
+    LOG.debug("Pathogenic motif counts for repeat id %s: %s", repeat_id, repeat_res)
 
     for repeat_number in repeat_res:
         if repeat_number <= rep_lower:
@@ -240,7 +242,7 @@ def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
             repeat_strings.append("full_mutation")
             rank_score = RANK_SCORE["full_mutation"]
             repeat_string = "full_mutation"
-
+    
     repeat_data = dict(
         most_severe_repeat_string=repeat_string,
         repeat_strings=repeat_strings,
@@ -279,11 +281,10 @@ def get_trgt_repeat_res(variant_info, repeat_info):
         if not mc:
             continue
 
-        max_count = 0
         for allele in mc.split(","):
             if allele == ".":
                 repeat_res.append(0)
-                break  # No motif count, so no repeat count
+                continue
 
             motif_counts = list(map(int, allele.split("_")))
             # GT would have the index of the MC in the ALT field list if we wanted to be specific...
@@ -294,13 +295,8 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                 count = sum(motif_counts)
             else:
                 count = sum(motif_counts[i] for i in pathologic_mcs if i < len(motif_counts))
-            # Keep only the maximum allele count for the repeat
-            max_count = max(max_count, count)
-        else:
-            repeat_res.append(max_count)
-
-        LOG.debug("Pathogenic motif count for repeat id %s: %s", repeat_id, max_count)
-        repeat_res.append(max_count)
+            
+            repeat_res.append(count)
 
     return repeat_res
 

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -283,8 +283,7 @@ def get_trgt_repeat_res(variant_info, repeat_info):
         for allele in mc.split(","):
             if allele == ".":
                 repeat_res.append(0)
-                break # No motif count, so no repeat count
-
+                break  # No motif count, so no repeat count
 
             motif_counts = list(map(int, allele.split("_")))
             # GT would have the index of the MC in the ALT field list if we wanted to be specific...
@@ -294,9 +293,7 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                 # we can just use the motif count as the repeat count.
                 count = sum(motif_counts)
             else:
-                count = sum(
-                    motif_counts[i] for i in pathologic_mcs if i < len(motif_counts)
-                )
+                count = sum(motif_counts[i] for i in pathologic_mcs if i < len(motif_counts))
             # Keep only the maximum allele count for the repeat
             max_count = max(max_count, count)
         else:

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -296,12 +296,16 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                 else:
                     pathologic_counts = int(allele)
                     pathologic_counts_per_allele[0] = int(allele)
-                
+
                 pathologic_counts_dict[allele_index] = pathologic_counts_per_allele
-           
-            max_sum = max(sum(v) if isinstance(v, list) else v for v in pathologic_counts_dict.values())
-            
-            LOG.warning("Old pathogenic repeat count for repeat id %s: %s", repeat_id, pathologic_counts)
+
+            max_sum = max(
+                sum(v) if isinstance(v, list) else v for v in pathologic_counts_dict.values()
+            )
+
+            LOG.warning(
+                "Old pathogenic repeat count for repeat id %s: %s", repeat_id, pathologic_counts
+            )
             LOG.warning("New pathogenic repeat count for repeat id %s: %s", repeat_id, max_sum)
         repeat_res.append(pathologic_counts)
 

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -224,7 +224,7 @@ def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
         repeat_res = get_trgt_repeat_res(variant_info, repeat_info)
     else:
         repeat_res = get_exhu_repeat_res_from_alts(variant_info)
-    
+
     LOG.debug("Pathogenic motif counts for repeat id %s: %s", repeat_id, repeat_res)
 
     for repeat_number in repeat_res:
@@ -242,7 +242,7 @@ def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
             repeat_strings.append("full_mutation")
             rank_score = RANK_SCORE["full_mutation"]
             repeat_string = "full_mutation"
-    
+
     repeat_data = dict(
         most_severe_repeat_string=repeat_string,
         repeat_strings=repeat_strings,
@@ -295,7 +295,7 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                 count = sum(motif_counts)
             else:
                 count = sum(motif_counts[i] for i in pathologic_mcs if i < len(motif_counts))
-            
+
             repeat_res.append(count)
 
     return repeat_res

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -275,7 +275,8 @@ def get_trgt_repeat_res(variant_info, repeat_info):
         pathologic_counts = 0
         mc = format_dict.get("MC")
         if mc:
-            for allele in mc.split(","):
+            pathologic_counts_dict = {}
+            for allele_index, allele in enumerate(mc.split(",")):
                 mcs = allele.split("_")
                 # GT would have the index of the MC in the ALT field list if we wanted to be specific...
 
@@ -284,14 +285,24 @@ def get_trgt_repeat_res(variant_info, repeat_info):
                     repeat_res.extend([0])
                     continue
 
+                pathologic_counts_per_allele = [0] * len(mcs)
                 if len(mcs) > 1:
                     pathologic_mcs = repeat_info[repeat_id].get("pathologic_struc", range(len(mcs)))
 
                     for index, count in enumerate(mcs):
                         if index in pathologic_mcs:
                             pathologic_counts += int(count)
+                            pathologic_counts_per_allele[index] = int(count)
                 else:
                     pathologic_counts = int(allele)
+                    pathologic_counts_per_allele[0] = int(allele)
+                
+                pathologic_counts_dict[allele_index] = pathologic_counts_per_allele
+           
+            max_sum = max(sum(v) if isinstance(v, list) else v for v in pathologic_counts_dict.values())
+            
+            LOG.warning("Old pathogenic repeat count for repeat id %s: %s", repeat_id, pathologic_counts)
+            LOG.warning("New pathogenic repeat count for repeat id %s: %s", repeat_id, max_sum)
         repeat_res.append(pathologic_counts)
 
     return repeat_res


### PR DESCRIPTION
## Description

Closes #92 

### Added

-

### Changed

-

### Fixed

- Fixed TRGT pathogenic motif count reporting sum of both alleles instead of longest


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
