### PR TITLE
Fix #95 - always use TRGT annotation keys, fix constant typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Fixed
 - Set STR_STATUS to most severe consequence for given repeat strings (TRGT decompose)
+- Always check and export TRGT repeat keys as well
 
 ## [0.9.4]
 ### Fixed

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -11,7 +11,7 @@ except ImportError:
 import click
 import coloredlogs
 
-from stranger.constants import ANNOTATE_REPEAT_KEYS, ANNOTATE_REPEAT_KEYS_TRGT
+from stranger.constants import ANNOTATE_REPEAT_KEYS
 from stranger.resources import repeats_json_path
 from stranger.utils import (
     decompose_var,
@@ -202,10 +202,7 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
                     [str(family_id), str(repeat_data["rank_score"])]
                 )
 
-                annotate_repeat_keys = ANNOTATE_REPEAT_KEYS
-                if trgt:
-                    annotate_repeat_keys = ANNOTATE_REPEAT_KEYS_TRGT
-                for annotate_repeat_key in annotate_repeat_keys:
+                for annotate_repeat_key in ANNOTATE_REPEAT_KEYS:
                     if repeat_data.get(annotate_repeat_key):
                         variant_info["info_dict"][annotate_repeat_key] = str(
                             repeat_data[annotate_repeat_key]

--- a/stranger/constants.py
+++ b/stranger/constants.py
@@ -1,6 +1,6 @@
 RANK_SCORE = {"normal": 10, "pre_mutation": 20, "full_mutation": 30}
 
-ANNOTATE_REPEAT_KEYS = [
+ANNOTATE_REPEAT_KEYS_EXHU = [
     "HGNCId",
     "InheritanceMode",
     "DisplayRU",
@@ -20,5 +20,8 @@ ANNOTATE_REPEAT_KEYS_TRGT = [
     "Source",
     "SourceId",
     "Disease",
-    "Struc" "PathologicStruc",
+    "Struc",
+    "PathologicStruc",
 ]
+
+ANNOTATE_REPEAT_KEYS = list(set(ANNOTATE_REPEAT_KEYS_EXHU + ANNOTATE_REPEAT_KEYS_TRGT))

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -86,11 +86,8 @@ def parse_json(file_handle):
         repeat_info[repid] = dict(normal_max=normal_max, pathologic_min=pathologic_min)
 
         for annotated_key in ANNOTATE_REPEAT_KEYS:
-            if repeat_unit.get(annotated_key):
+            if annotated_key in repeat_unit:
                 repeat_info[repid][annotated_key] = repeat_unit.get(annotated_key)
-
-        if "PathologicStruc" in repeat_unit:
-            repeat_info[repid]["pathologic_struc"] = repeat_unit["PathologicStruc"]
 
         if "TRID" in repeat_unit:
             # TRGT uses TRID instead of REPID
@@ -99,11 +96,8 @@ def parse_json(file_handle):
             repeat_info[trid] = dict(normal_max=normal_max, pathologic_min=pathologic_min)
 
             for annotated_key in ANNOTATE_REPEAT_KEYS:
-                if repeat_unit.get(annotated_key):
+                if annotated_key in repeat_unit:
                     repeat_info[trid][annotated_key] = repeat_unit.get(annotated_key)
-
-            if "PathologicStruc" in repeat_unit:
-                repeat_info[trid]["pathologic_struc"] = repeat_unit["PathologicStruc"]
 
         # From ExHu 3.0 repids include the region of interest.
         try:


### PR DESCRIPTION
## Description

### Fixed

- Always check and export TRGT repeat keys


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
