### PR TITLE
Fix #88 - docker image provenance, build actions update

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -25,13 +25,26 @@ jobs:
    runs-on: ubuntu-latest
    steps:
 
-    - name: Check out git repository
-      uses: actions/checkout@v4
+     - name: Check out git repository
+       uses: actions/checkout@v4
 
-    - name: Publish main image (Dockerfile) to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v5
-      with:
-        name: clinicalgenomics/stranger
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ github.event.release.tag_name }}"
+     - name: Login to Docker Hub
+       uses: docker/login-action@v3
+       with:
+         username: ${{ secrets.DOCKER_USERNAME }}
+         password: ${{ secrets.DOCKER_PASSWORD }}
+
+     - name: Set up Docker Buildx
+       id: buildx
+       uses: docker/setup-buildx-action@v3
+
+     - name: Build and push
+       uses: docker/build-push-action@v6
+       with:
+         context: ./
+         file: ./Dockerfile
+         provenance: mode=max
+         sbom: true
+         push: true
+         tags: "clinicalgenomics/stranger:${{ github.event.release.tag_name }}, clinicalgenomics/stranger:latest"
+

--- a/.github/workflows/server_stage_docker_push.yml
+++ b/.github/workflows/server_stage_docker_push.yml
@@ -29,9 +29,11 @@ jobs:
 
      - name: Build and push
        if: steps.branch-name.outputs.is_default == 'false'
-       uses: docker/build-push-action@v5
+       uses: docker/build-push-action@v6
        with:
          context: ./
          file: ./Dockerfile
+         provenance: mode=max
+         sbom: true
          push: true
          tags: "clinicalgenomics/stranger-stage:${{steps.branch-name.outputs.current_branch}}, clinicalgenomics/stranger-stage:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
+### Changed
+- Updated build actions, set Docker build provenance, use two-stage build and a non-root user for Docker image
 ### Fixed
 - Set STR_STATUS to most severe consequence for given repeat strings (TRGT decompose)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,26 @@
 #   docker run -v $PWD:$PWD clinical-genomics/stranger:v0.9.0 stranger --help
 #   docker run -v $PWD:$PWD clinical-genomics/stranger:v0.9.0 stranger -f /bin/stranger/stranger/resources/variant_catalog_hg38.json $PWD/sample.joint.repeats.merged.vcf.gz > $PWD/sample.repeats.stranger.vcf
 ###############################################
-FROM ghcr.io/astral-sh/uv:python3.13-alpine
+FROM ghcr.io/astral-sh/uv:python3.13-alpine AS builder
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
 # Copy the project into the image
 ADD . /app
 
 # Sync the project into a new environment, using the frozen lockfile
 WORKDIR /app
-RUN uv sync --frozen
+RUN uv sync --locked --no-dev
 
+FROM ghcr.io/astral-sh/uv:python3.13-alpine
 
-ENTRYPOINT ["uv", "run", "stranger"]
+RUN addgroup app && adduser -D -s /sbin/nologin -G app app
+
+WORKDIR /home/worker/app
+
+COPY --from=builder --chown=app:app /app /app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+USER app
+
+ENTRYPOINT ["stranger"]


### PR DESCRIPTION
## Description

- Fix #88

### Changed

- Updated build actions, set Docker build provenance, use two-stage build and a non-root user for Docker image

![Screenshot 2025-06-17 at 11 54 56](https://github.com/user-attachments/assets/0c61085b-ca8e-48d3-9db0-e19b0813e2e3)

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [x] Do let github actions build image

### Expected test outcome

- [x] Check that docker image is built, pushed to github with good health status
- [x] Take a screenshot and attach or copy/paste the output.



## Review

- [ ] Tests executed by github actions
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
