### PR TITLE
Fix strchive c9orf72 arx repid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - More TRGT PathologicStruc locus annotations to demo resources
 - Always check and export TRGT repeat keys as well
 - Motif counts for TRGT alleles erroneously summed
+- TRID for a couple of STRchive style entries with "_" need exact matching since the gene id alone is not unique
 
 ## [0.9.4]
 ### Fixed

--- a/stranger/resources/variant_catalog_grch37.json
+++ b/stranger/resources/variant_catalog_grch37.json
@@ -515,6 +515,7 @@
         "SweGenMean": 11.32,
         "SweGenStd": 6.946,
         "LocusStructure": "(A)*(GAA)*",
+        "Motifs": ["A","GAA"],
         "PathologicStruc": [1],
         "ReferenceRegion": [
             "9:71652177-71652202",

--- a/stranger/resources/variant_catalog_grch38.json
+++ b/stranger/resources/variant_catalog_grch38.json
@@ -725,6 +725,8 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(A)*(GAA)*",
+        "Motifs": ["A","GAA"],
+        "PathologicStruc": [1],
         "ReferenceRegion": [
             "9:69037261-69037286",
             "9:69037286-69037304"
@@ -737,7 +739,6 @@
             "Repeat",
             "Repeat"
         ],
-        "PathologicStruc": [1],
         "Disease": "FRDA",
         "NormalMax": 35,
         "PathologicMin": 51,

--- a/stranger/resources/variant_catalog_hg19.json
+++ b/stranger/resources/variant_catalog_hg19.json
@@ -514,6 +514,7 @@
         "SweGenMean": 11.32,
         "SweGenStd": 6.946,
         "LocusStructure": "(A)*(GAA)*",
+        "Motifs": ["A","GAA"],
         "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr9:71652177-71652202",

--- a/stranger/resources/variant_catalog_hg38.json
+++ b/stranger/resources/variant_catalog_hg38.json
@@ -726,6 +726,7 @@
         "Source": "GeneReviews",
         "SourceId": "NBK535148",
         "LocusStructure": "(A)*(GAA)*",
+        "Motifs": ["A","GAA"],
         "PathologicStruc": [1],
         "ReferenceRegion": [
             "chr9:69037261-69037286",

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -172,7 +172,7 @@ def get_repeat_id(variant_info: dict, repeat_info: dict) -> str:
     if not trid:
         return None
 
-    if trid == repeat_info.get("TRID"):
+    if trid in repeat_info:
         return trid
 
     if "_" in trid:

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -153,7 +153,7 @@ def get_exhu_repeat_res_from_alts(variant_info: dict) -> list:
     return repeat_res
 
 
-def get_repeat_id(variant_info:dict, repeat_info:dict)->str:
+def get_repeat_id(variant_info: dict, repeat_info: dict) -> str:
     """
     First tries to get variant id from REPID,
     if that is not successful, try to get variant id from TRID (TRGT).

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -153,12 +153,13 @@ def get_exhu_repeat_res_from_alts(variant_info: dict) -> list:
     return repeat_res
 
 
-def get_repeat_id(variant_info):
+def get_repeat_id(variant_info:dict, repeat_info:dict)->str:
     """
     First tries to get variant id from REPID,
-    if that is not sucessful, try to get variant id from TRID (TRGT).
-    If the ID is formatted with underscore (STRchive),
-    grab the part which is after the underscore, otherwise take the whole ID (PacBio).
+    if that is not successful, try to get variant id from TRID (TRGT).
+    If there is an exact match between TRID in repeat config info and variant, use it.
+    Else, if the ID is formatted with underscore (STRchive),
+    grab the part which is after the underscore, or otherwise take the whole ID (PacBio).
     """
     info_dict = variant_info.get("info_dict", {})
 
@@ -170,6 +171,9 @@ def get_repeat_id(variant_info):
 
     if not trid:
         return None
+
+    if trid == repeat_info.get("TRID"):
+        return trid
 
     if "_" in trid:
         return trid.split("_", 1)[1]
@@ -189,7 +193,7 @@ def get_repeat_info(variant_info: dict, repeat_info: dict) -> dict:
     """
 
     # There can be one or more alternatives (each ind can have at most two of those)
-    repeat_id = get_repeat_id(variant_info)
+    repeat_id = get_repeat_id(variant_info, repeat_info)
 
     if not repeat_id in repeat_info:
         LOG.warning("No info for repeat id %s", repeat_id)
@@ -255,7 +259,7 @@ def get_trgt_repeat_res(variant_info, repeat_info):
     If MC is ".", ref, we append a [0] to the result. This could be improved given a known REF size.
     """
 
-    repeat_id = get_repeat_id(variant_info)
+    repeat_id = get_repeat_id(variant_info, repeat_info)
 
     if not repeat_id in repeat_info:
         LOG.warning("No info for repeat id %s", repeat_id)


### PR DESCRIPTION
## Description


### Fixed

- A couple of TRID in STRchive definition bed need exact name match to a given TRID in the repeat info config json, instead of match on name split on `_` and matching on gene symbol. This includes non-unique gene genes, that need their disease given as a pair, and C9orf72 for the funky case.

❌ Before:
```
2025-06-19 17:51:14 hasta-login.local stranger.utils[262537] WARNING No info for repeat id HOXA13-III
2025-06-19 17:51:14 hasta-login.local stranger.utils[262537] WARNING No info for repeat id C9orf72
2025-06-19 17:51:14 hasta-login.local stranger.utils[262537] WARNING No info for repeat id C9orf72
2025-06-19 17:51:14 hasta-login.local stranger.utils[262537] WARNING No info for repeat id PRDM12
2025-06-19 17:51:14 hasta-login.local stranger.utils[262537] WARNING No info for repeat id MUC1
```
✅ After:
```
2025-06-19 17:58:34 hasta-login.local stranger.utils[264184] WARNING No info for repeat id HOXA13-III
2025-06-19 17:58:34 hasta-login.local stranger.utils[264184] WARNING No info for repeat id PRDM12
2025-06-19 17:58:34 hasta-login.local stranger.utils[264184] WARNING No info for repeat id MUC1
```

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
