### PR TITLE
Fix malformed GT fields when REF allele in TRGT mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Prevent malformed GT fields by preserving `0` REF alleles during TRGT multi-ALT decomposition
+
 ## [0.10.0]
 ### Added
 - Support for phased genotypes

--- a/stranger/utils.py
+++ b/stranger/utils.py
@@ -424,6 +424,7 @@ def decompose_var(variant_info):
                 if decomposed_field in ["0", "."]:
                     # reference component 0, uncalled component .
                     updated_fields.append(decomposed_field)
+                    continue
 
                 if decomposed_field.isdigit():
                     if int(decomposed_field) == index + 1:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,3 +157,33 @@ def test_phased_gt():
     # THEN assert we have phased GTs after decomposition
     gts = [variant["format_dicts"][0]["GT"] for variant in decomposed]
     assert gts == ["1|.", ".|1"]
+
+
+def test_multiallelic_gt_with_reference_allele():
+    # GIVEN a variant with a reference allele and one ALT allele in GT
+    variant_info = {
+        "alts": ["A", "C"],
+        "format_dicts": [{"GT": "0/2"}],
+    }
+
+    # WHEN decomposing the variant
+    decomposed = decompose_var(variant_info)
+
+    # THEN keep the reference allele intact when splitting GT
+    gts = [variant["format_dicts"][0]["GT"] for variant in decomposed]
+    assert gts == ["0/.", "0/1"]
+
+
+def test_multiallelic_phased_gt_with_reference_allele():
+    # GIVEN a phased variant with a reference allele and one ALT allele in GT
+    variant_info = {
+        "alts": ["A", "C"],
+        "format_dicts": [{"GT": "0|2"}],
+    }
+
+    # WHEN decomposing the variant
+    decomposed = decompose_var(variant_info)
+
+    # THEN keep the reference allele intact when splitting GT
+    gts = [variant["format_dicts"][0]["GT"] for variant in decomposed]
+    assert gts == ["0|.", "0|1"]


### PR DESCRIPTION
## Description

Sorry for the multiple PRs. The previous two seemed to have failed due to slash in the previous branch name.

fixes #112 

### Added

- Tests for decomposing multi-ALT variants with REF alleles

### Changed

-

### Fixed

- #112 


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
