### PR TITLE
Multi allele status header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Prevent malformed GT fields by preserving `0` REF alleles during TRGT multi-ALT decomposition
+- VCF header to show STR_STATUS as 1 instead of A as this is most severe status as of 0.9.5
 
 ## [0.10.0]
 ### Added

--- a/stranger/cli.py
+++ b/stranger/cli.py
@@ -73,9 +73,9 @@ def cli(context, vcf, family_id, repeats_file, loglevel, trgt):
     header_info_definitions = [
         {
             "id": "STR_STATUS",
-            "num": "A",
+            "num": "1",
             "type": "String",
-            "desc": "Repeat expansion status. Alternatives in [normal, pre_mutation, full_mutation]",
+            "desc": "Repeat expansion most severe status. Alternatives in [normal, pre_mutation, full_mutation]",
         },
         {
             "id": "STR_NORMAL_MAX",


### PR DESCRIPTION
- Fix #111

## Description

### Fixed

- VCF header to show STR_STATUS as 1 instead of A as this is most severe status as of 0.9.5


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
